### PR TITLE
検索結果画面においてA+つくばへのリンクを追加

### DIFF
--- a/result.html.tmpl
+++ b/result.html.tmpl
@@ -21,7 +21,8 @@
         <section>
             <h2>{{.Source.CourseID}}: {{.Source.Title}}</h2>
             <p>{{.Source.Summary}}</p>
-            <a href="https://kdb.tsukuba.ac.jp/syllabi/2023/{{.Source.CourseID}}/jpn/">KdB</a>
+            <a href="https://kdb.tsukuba.ac.jp/syllabi/2023/{{.Source.CourseID}}/jpn/">KdB</a> 
+            <a href="https://www.aplus-tsukuba.net/threads/codes/{{.Source.CourseID}}">A+つくば</a>
         </section>
         {{ end }}
     </main>


### PR DESCRIPTION
検索結果画面において、[A+つくば](https://www.aplus-tsukuba.net)様の各科目ページへのリンクを表示できるようにしました